### PR TITLE
Fix typo in initial migration

### DIFF
--- a/migrations/m141208_201481_cms_init.php
+++ b/migrations/m141208_201481_cms_init.php
@@ -9,7 +9,7 @@ use yii\db\Schema;
  *
  * Create blog tables.
  *
- * Will be created 4 tables:
+ * This will create 2 tables:
  * - `{{%cms_catalog}}` - Cms catalog or page
  * - `{{%cms_show}}` - Cms page of list item
  */


### PR DESCRIPTION
The migration creates 2 (not 4) tables.
